### PR TITLE
Validate JWT_SECRET at startup

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -8,7 +8,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'default-secret',
+      secretOrKey: process.env.JWT_SECRET,
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ import { AppModule } from './app.module';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
 
 async function bootstrap() {
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is not defined');
+  }
   const app = await NestFactory.create(AppModule);
 
   // CORS más restrictivo para producción


### PR DESCRIPTION
## Summary
- remove the fallback `'default-secret'`
- validate that `JWT_SECRET` is set during bootstrap

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6b6c2f90832094c0d87a76a598f2